### PR TITLE
Fix publishing in .NET 6, avoid trimming

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         path: ./TestResults
       if: ${{ always() }} # Always run this step even on failure
     - name: Publish
-      run: dotnet publish Website/Src --configuration Release --runtime linux-x64 --self-contained true -p:PublishReadyToRun=true -p:PublishSingleFile=true -p:PublishTrimmed=true --no-restore --output artifacts
+      run: dotnet publish Website/Src --configuration Release --runtime linux-x64 --self-contained true -p:PublishReadyToRun=true -p:PublishSingleFile=true --no-restore --output artifacts
     - name: Upload published website
       uses: actions/upload-artifact@v2
       with:

--- a/Website/Src/Website.csproj
+++ b/Website/Src/Website.csproj
@@ -25,11 +25,14 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="3.1.1" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Sendgrid" Version="9.25.3" />
+      
+    <!-- Resolve some NU1605 errors -->
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Not sure why I'm seeing NU1605 errors, and only when publishing.

Trimming has a ton of new errors as well, so I'm just turning it off.