### PR TITLE
Add 3y and 5y time ranges

### DIFF
--- a/WebClient/src/components/userCompare/userCompare.spec.ts
+++ b/WebClient/src/components/userCompare/userCompare.spec.ts
@@ -178,6 +178,8 @@ describe("UserCompareComponent", () => {
                 "1m": new Date(new Date(now).setMonth(expectedEnd.getMonth() - 1)),
                 "3m": new Date(new Date(now).setMonth(expectedEnd.getMonth() - 3)),
                 "1y": new Date(new Date(now).setFullYear(expectedEnd.getFullYear() - 1)),
+                "3y": new Date(new Date(now).setFullYear(expectedEnd.getFullYear() - 3)),
+                "5y": new Date(new Date(now).setFullYear(expectedEnd.getFullYear() - 5)),
             };
 
             expect(component.ranges.length).toEqual(Object.keys(expectedStarts).length);

--- a/WebClient/src/components/userCompare/userCompare.ts
+++ b/WebClient/src/components/userCompare/userCompare.ts
@@ -27,6 +27,8 @@ export class UserCompareComponent implements OnInit {
         "1m",
         "3m",
         "1y",
+        "3y",
+        "5y",
     ];
     private static readonly ascensionRanges = [
         "10",
@@ -106,6 +108,9 @@ export class UserCompareComponent implements OnInit {
             case "3d":
                 startOrPage.setDate(startOrPage.getDate() - 3);
                 break;
+            case "1w":
+                startOrPage.setDate(startOrPage.getDate() - 7);
+                break;
             case "1m":
                 startOrPage.setMonth(startOrPage.getMonth() - 1);
                 break;
@@ -115,8 +120,11 @@ export class UserCompareComponent implements OnInit {
             case "1y":
                 startOrPage.setFullYear(startOrPage.getFullYear() - 1);
                 break;
-            case "1w":
-                startOrPage.setDate(startOrPage.getDate() - 7);
+            case "3y":
+                startOrPage.setFullYear(startOrPage.getFullYear() - 3);
+                break;
+            case "5y":
+                startOrPage.setFullYear(startOrPage.getFullYear() - 5);
                 break;
             default:
                 // Using Ascension range

--- a/WebClient/src/components/userProgress/userProgress.spec.ts
+++ b/WebClient/src/components/userProgress/userProgress.spec.ts
@@ -152,6 +152,8 @@ describe("UserProgressComponent", () => {
                 "1m": new Date(new Date(now).setMonth(expectedEnd.getMonth() - 1)),
                 "3m": new Date(new Date(now).setMonth(expectedEnd.getMonth() - 3)),
                 "1y": new Date(new Date(now).setFullYear(expectedEnd.getFullYear() - 1)),
+                "3y": new Date(new Date(now).setFullYear(expectedEnd.getFullYear() - 3)),
+                "5y": new Date(new Date(now).setFullYear(expectedEnd.getFullYear() - 5)),
             };
 
             expect(component.ranges.length).toEqual(Object.keys(expectedStarts).length);

--- a/WebClient/src/components/userProgress/userProgress.ts
+++ b/WebClient/src/components/userProgress/userProgress.ts
@@ -28,6 +28,8 @@ export class UserProgressComponent implements OnInit {
         "1m",
         "3m",
         "1y",
+        "3y",
+        "5y",
     ];
     private static readonly ascensionRanges = [
         "10",
@@ -109,6 +111,9 @@ export class UserProgressComponent implements OnInit {
             case "3d":
                 startOrPage.setDate(startOrPage.getDate() - 3);
                 break;
+            case "1w":
+                startOrPage.setDate(startOrPage.getDate() - 7);
+                break;
             case "1m":
                 startOrPage.setMonth(startOrPage.getMonth() - 1);
                 break;
@@ -118,8 +123,11 @@ export class UserProgressComponent implements OnInit {
             case "1y":
                 startOrPage.setFullYear(startOrPage.getFullYear() - 1);
                 break;
-            case "1w":
-                startOrPage.setDate(startOrPage.getDate() - 7);
+            case "3y":
+                startOrPage.setFullYear(startOrPage.getFullYear() - 3);
+                break;
+            case "5y":
+                startOrPage.setFullYear(startOrPage.getFullYear() - 5);
                 break;
             default:
                 // Using Ascension range


### PR DESCRIPTION
Based on user feedback:

> At this point with more people reaching endgame (HZE > 2M), transcends are taking longer than 1 year. Could we get additional selections of 2 years and/or 5 years of history displayed?

Adding a custom time range would be good to add in the future as well. I may look into that later.